### PR TITLE
Managed responses system

### DIFF
--- a/src/ElectronServer.js
+++ b/src/ElectronServer.js
@@ -28,7 +28,21 @@ const Electron = require('electron'),
     Path = require('path'),
     DNode = require('dnode'),
     QueryString = require('querystring'),
-    Logger = require('./Logger.js');
+    Logger = require('./Logger.js'),
+    ResponseManager = {
+        responses: {},
+        create: function () {
+            var id = uuid.v1();
+            this.responses[id] = {payload: null, id: id, created: Date.now()};
+            return id;
+        },
+        get: function (id) {
+            return this.responses[id].payload;
+        },
+        set: function (id, payload) {
+            this.responses[id].payload = payload;
+        }
+    };
 
 var showWindow = process.argv[3] === 'show';
 Logger.LogLevel = process.argv[4] || Logger.WARNING;


### PR DESCRIPTION
# Managed / Tracked Responses

## Problem Description
Currently the JS server makes heavy use of global variables or variables shared across RPC calls, especially response variables.
This produces a whole host of problems, for example a slow async process might interfere with a more recent async process by overwriting response variables causing an early return with the wrong payload data. Moreover, as it is, it's very difficult to figure out who did what and why a particular payload is returned.

## Solution
A having a sort of registry of responses. This registry should be cleaned automatically. Example of use:
```
--> client requests visiting URL
<-- server creates empty payload and returns the newly created payload_id
--> client repeatedly polls the server with the payload_id
--- when servers finally receives confirmation that new page was loaded updates payload content
<-- on next client polling for payload_id, server returns payload and removes it from registry
```
At some points the server should do some maintenance to the payload registry:
- delete very old payloads (pending and resolved payloads)
- disallow requests when number of payloads exceed a certain value
- if the payload_id is an incremental index, reset it at some point

## Things to Consider
- What should the `payload_id` be? Possible candidates:
  - incremental number (needs to be reset eventually)
  - timestamp (`Date.now()` for ms or `process.hrtime()` for μs)
  - UUID v4, via node-uuid
- What's the maximum number of allowed payloads?
  - maybe the limit should be computed relatively to memory usage and payload count
- What's the time limit when payloads should be purged, irrelevant of their state?
- Should we clean up payloads periodically or remove the payload immediately when after it's requested by the client?